### PR TITLE
Allow to configure default values for `assignee`, `component` and `developer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Make sure to store your JIRA Personal Access Token (PAT) in the `~/.config/story
 JIRA_API_TOKEN="exaple-token"
 ```
 
+> [!TIP]
+>
+> You can also set default values for the `assignee`, `developer`, and `component` fields in the `~/.config/storypointer/.env` or `~/.env.storypointer` file:
+>
+> ```bash
+> # ~/.config/storypointer/.env
+> ASSIGNEE="your-jira-username"
+> DEVELOPER="your-jira-username"
+> COMPONENT="your-component"
+> ```
+
 ### Using Node.js
 
 ```bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -205,11 +205,6 @@ const cli = async () => {
     );
     await jira.setValues(issue.key, priority, storyPoints);
   }
-
-  // loop through issues and ask for story points and priority
-  //? allow to end at any time
-
-  //? print statistics
 };
 
 try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import '@total-typescript/ts-reset';
 
 import { Jira } from './jira';
 import { getLegend } from './legend';
-import { raise, tokenUnavailable } from './util';
+import { getOptions, raise, tokenUnavailable } from './util';
 
 import {
   colorPrioritySchema,
@@ -50,7 +50,7 @@ const cli = async () => {
 
   program.parse();
 
-  const options = program.opts();
+  const options = getOptions(program.opts());
 
   if (options.legend) {
     console.log(getLegend());

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { OptionValues } from 'commander';
+
 export function raise(error: string): never {
   throw new Error(error);
 }
@@ -6,4 +8,19 @@ export function tokenUnavailable(): never {
   return raise(
     `JIRA_API_TOKEN not set.\nPlease set the JIRA_API_TOKEN environment variable in '~/.config/storypointer/.env' or '~/.env.storypointer' or '~/.env.'`
   );
+}
+
+export function getDefaultValue(
+  envName: 'ASSIGNEE' | 'COMPONENT' | 'DEVELOPER'
+) {
+  return process.env[envName];
+}
+
+export function getOptions(inputs: OptionValues): OptionValues {
+  return {
+    ...inputs,
+    assignee: inputs.assignee || getDefaultValue('ASSIGNEE'),
+    component: inputs.component || getDefaultValue('COMPONENT'),
+    developer: inputs.developer || getDefaultValue('DEVELOPER'),
+  };
 }


### PR DESCRIPTION
The `.env` files can be used to configure default values. For more information, see the README.md file.